### PR TITLE
Implement basic frontend with configurable base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ The server will start on `:8080`.
 
 ## Frontend
 
-Open `frontend/public/index.html` in your browser or visit `http://localhost:8080` after running the backend.
+Set the API base URL in `frontend/public/config.js` if the backend runs on a different host.
+Open `frontend/public/index.html` in your browser. From the navigation you can access login, register and order pages.

--- a/frontend/public/about.html
+++ b/frontend/public/about.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<title>about</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100 text-center">
+<h1 class="text-2xl font-bold mb-4">صفحه about</h1>
+<p>در دست ساخت.</p>
+<a href="index.html" class="text-blue-600">بازگشت</a>
+</body>
+</html>

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>پنل ادمین</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100">
+    <h1 class="text-2xl font-bold mb-4">سفارش‌ها</h1>
+    <table class="w-full text-right border" id="ordersTbl">
+        <thead>
+            <tr>
+                <th class="border px-2">شناسه</th>
+                <th class="border px-2">وضعیت</th>
+                <th class="border px-2">کاربر</th>
+                <th class="border px-2">اقدامات</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="config.js"></script>
+    <script>
+    async function loadOrders() {
+        const res = await fetch(window.API_BASE_URL + '/admin/orders', {
+            headers: {
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            }
+        });
+        const data = await res.json();
+        const tbody = document.querySelector('#ordersTbl tbody');
+        tbody.innerHTML = '';
+        data.forEach(o => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td class="border px-2">${o.ID}</td>`+
+                `<td class="border px-2">${o.Status}</td>`+
+                `<td class="border px-2">${o.UserID}</td>`+
+                `<td class="border px-2 space-x-reverse space-x-2">
+                    <button onclick="verify(${o.ID})" class='bg-blue-500 text-white px-2 rounded'>تایید</button>
+                    <button onclick="assign(${o.ID})" class='bg-green-500 text-white px-2 rounded'>انتساب</button>
+                </td>`;
+            tbody.appendChild(tr);
+        });
+    }
+    async function verify(id) {
+        await fetch(window.API_BASE_URL + `/admin/orders/${id}/verify`, {
+            method:'POST',
+            headers:{
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            }
+        });
+        loadOrders();
+    }
+    async function assign(id) {
+        const emp = prompt('شناسه کارمند؟');
+        if(!emp) return;
+        await fetch(window.API_BASE_URL + `/admin/orders/${id}/assign`, {
+            method:'POST',
+            headers:{
+                'Content-Type':'application/json',
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            },
+            body: JSON.stringify({ employee_id: parseInt(emp) })
+        });
+        loadOrders();
+    }
+    loadOrders();
+    </script>
+</body>
+</html>

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,0 +1,3 @@
+// API base URL. Change this if backend runs on a different host.
+// Default is empty string which means same host serving the frontend.
+window.API_BASE_URL = window.API_BASE_URL || '';

--- a/frontend/public/contact.html
+++ b/frontend/public/contact.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<title>contact</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100 text-center">
+<h1 class="text-2xl font-bold mb-4">صفحه contact</h1>
+<p>در دست ساخت.</p>
+<a href="index.html" class="text-blue-600">بازگشت</a>
+</body>
+</html>

--- a/frontend/public/create_order.html
+++ b/frontend/public/create_order.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>سفارش جدید</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center bg-gray-100">
+    <form id="orderForm" class="bg-white p-6 rounded shadow-md w-full max-w-md">
+        <h1 class="text-xl font-bold mb-4 text-center">سفارش شیشه روی میز</h1>
+        <input id="thickness" type="number" step="0.1" placeholder="ضخامت" class="border p-2 w-full mb-3" required>
+        <input id="color" type="text" placeholder="رنگ" class="border p-2 w-full mb-3" required>
+        <input id="pocket" type="text" placeholder="پاکت" class="border p-2 w-full mb-3">
+        <label class="block mb-1">نوع شکل</label>
+        <select id="shape" class="border p-2 w-full mb-3">
+            <option value="rectangular">مستطیل</option>
+            <option value="circular">دایره</option>
+            <option value="polygon">چندضلعی</option>
+        </select>
+        <div id="rectFields" class="hidden">
+            <input id="width" type="number" step="0.1" placeholder="عرض" class="border p-2 w-full mb-3">
+            <input id="height" type="number" step="0.1" placeholder="طول" class="border p-2 w-full mb-3">
+        </div>
+        <div id="circFields" class="hidden">
+            <input id="diameter" type="number" step="0.1" placeholder="قطر" class="border p-2 w-full mb-3">
+        </div>
+        <div id="polyFields" class="hidden">
+            <input id="description" type="text" placeholder="توضیحات" class="border p-2 w-full mb-3">
+        </div>
+        <button class="bg-blue-500 hover:bg-blue-600 text-white w-full py-2 rounded" type="submit">ثبت سفارش</button>
+    </form>
+    <script src="config.js"></script>
+    <script>
+    const shapeSelect = document.getElementById('shape');
+    const rect = document.getElementById('rectFields');
+    const circ = document.getElementById('circFields');
+    const poly = document.getElementById('polyFields');
+
+    function updateFields() {
+        rect.classList.add('hidden');
+        circ.classList.add('hidden');
+        poly.classList.add('hidden');
+        if (shapeSelect.value === 'rectangular') rect.classList.remove('hidden');
+        if (shapeSelect.value === 'circular') circ.classList.remove('hidden');
+        if (shapeSelect.value === 'polygon') poly.classList.remove('hidden');
+    }
+    shapeSelect.addEventListener('change', updateFields);
+    updateFields();
+
+    document.getElementById('orderForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const body = {
+            thickness: parseFloat(document.getElementById('thickness').value),
+            color: document.getElementById('color').value,
+            round_trim: false,
+            pocket: document.getElementById('pocket').value,
+            shape_type: shapeSelect.value,
+            width: parseFloat(document.getElementById('width').value),
+            height: parseFloat(document.getElementById('height').value),
+            diameter: parseFloat(document.getElementById('diameter').value),
+            description: document.getElementById('description').value
+        };
+        const res = await fetch(window.API_BASE_URL + '/orders', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            },
+            body: JSON.stringify(body)
+        });
+        const data = await res.json();
+        if (res.ok) {
+            alert('سفارش ثبت شد با شناسه ' + data.ID);
+        } else {
+            alert(data.error || 'خطا در ثبت سفارش');
+        }
+    });
+    </script>
+</body>
+</html>

--- a/frontend/public/employee.html
+++ b/frontend/public/employee.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>پنل کارمند</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100">
+    <h1 class="text-2xl font-bold mb-4">سفارش‌های من</h1>
+    <table class="w-full text-right border" id="ordersTbl">
+        <thead>
+            <tr>
+                <th class="border px-2">شناسه</th>
+                <th class="border px-2">وضعیت</th>
+                <th class="border px-2">اقدام</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="config.js"></script>
+    <script>
+    async function loadOrders() {
+        // For simplicity admin/orders endpoint used and filtered by AssignedTo
+        const res = await fetch(window.API_BASE_URL + '/admin/orders', {
+            headers:{
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            }
+        });
+        const data = await res.json();
+        const myId = parseInt(localStorage.getItem('userID') || '0');
+        const tbody = document.querySelector('#ordersTbl tbody');
+        tbody.innerHTML = '';
+        data.filter(o => o.AssignedTo == myId).forEach(o => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td class="border px-2">${o.ID}</td>`+
+                `<td class="border px-2">${o.Status}</td>`+
+                `<td class="border px-2"><button onclick="approve(${o.ID})" class='bg-blue-500 text-white px-2 rounded'>تایید</button></td>`;
+            tbody.appendChild(tr);
+        });
+    }
+    async function approve(id){
+        await fetch(window.API_BASE_URL + `/employee/orders/${id}/approve`, {
+            method:'POST',
+            headers:{
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            }
+        });
+        loadOrders();
+    }
+    loadOrders();
+    </script>
+</body>
+</html>

--- a/frontend/public/followup.html
+++ b/frontend/public/followup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<title>followup</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100 text-center">
+<h1 class="text-2xl font-bold mb-4">صفحه followup</h1>
+<p>در دست ساخت.</p>
+<a href="index.html" class="text-blue-600">بازگشت</a>
+</body>
+</html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -54,6 +54,8 @@
                 <a href="about.html" class="text-gray-600 hover:text-blue-600 transition duration-300">درباره ما</a>
                 <a href="contact.html" class="text-gray-600 hover:text-blue-600 transition duration-300">تماس با ما</a>
                 <a href="followup.html" class="text-gray-600 hover:text-blue-600 transition duration-300">پیگیری سفارش</a>
+                <a href="login.html" class="text-gray-600 hover:text-blue-600 transition duration-300">ورود</a>
+                <a href="register.html" class="text-gray-600 hover:text-blue-600 transition duration-300">ثبت نام</a>
             </div>
         </nav>
     </header>
@@ -64,6 +66,7 @@
             <h1 class="text-5xl font-extrabold mb-4 leading-tight">راهکارهای دقیق برش شیشه</h1>
             <p class="text-xl mb-8 opacity-90">همراه مطمئن شما در ساخت شیشه‌های سفارشی</p>
             <a href="services.html" class="btn-primary inline-block font-semibold shadow-lg">مشاهده خدمات</a>
+            <a href="create_order.html" class="btn-primary inline-block font-semibold shadow-lg mt-4">ثبت سفارش</a>
         </div>
     </section>
 

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ورود</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center bg-gray-100">
+    <form id="loginForm" class="bg-white p-6 rounded shadow-md w-full max-w-sm">
+        <h1 class="text-xl font-bold mb-4 text-center">ورود</h1>
+        <input id="email" type="email" placeholder="ایمیل" class="border p-2 w-full mb-3" required>
+        <input id="password" type="password" placeholder="رمز عبور" class="border p-2 w-full mb-3" required>
+        <button class="bg-blue-500 hover:bg-blue-600 text-white w-full py-2 rounded" type="submit">ورود</button>
+    </form>
+    <script src="config.js"></script>
+    <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const res = await fetch(window.API_BASE_URL + '/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password })
+        });
+        const data = await res.json();
+        if (res.ok) {
+            localStorage.setItem('userID', data.id);
+            localStorage.setItem('role', data.role);
+            alert('ورود موفقیت آمیز بود');
+            window.location.href = 'index.html';
+        } else {
+            alert(data.error || 'خطا در ورود');
+        }
+    });
+    </script>
+</body>
+</html>

--- a/frontend/public/privacy.html
+++ b/frontend/public/privacy.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<title>privacy</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100 text-center">
+<h1 class="text-2xl font-bold mb-4">صفحه privacy</h1>
+<p>در دست ساخت.</p>
+<a href="index.html" class="text-blue-600">بازگشت</a>
+</body>
+</html>

--- a/frontend/public/products.html
+++ b/frontend/public/products.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<title>products</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100 text-center">
+<h1 class="text-2xl font-bold mb-4">صفحه products</h1>
+<p>در دست ساخت.</p>
+<a href="index.html" class="text-blue-600">بازگشت</a>
+</body>
+</html>

--- a/frontend/public/register.html
+++ b/frontend/public/register.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ثبت نام</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center bg-gray-100">
+    <form id="registerForm" class="bg-white p-6 rounded shadow-md w-full max-w-sm">
+        <h1 class="text-xl font-bold mb-4 text-center">ثبت نام</h1>
+        <input id="name" type="text" placeholder="نام" class="border p-2 w-full mb-3" required>
+        <input id="email" type="email" placeholder="ایمیل" class="border p-2 w-full mb-3" required>
+        <input id="password" type="password" placeholder="رمز عبور" class="border p-2 w-full mb-3" required>
+        <button class="bg-green-500 hover:bg-green-600 text-white w-full py-2 rounded" type="submit">ثبت نام</button>
+    </form>
+    <script src="config.js"></script>
+    <script>
+    document.getElementById('registerForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const name = document.getElementById('name').value;
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const res = await fetch(window.API_BASE_URL + '/register', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, email, password })
+        });
+        const data = await res.json();
+        if (res.ok) {
+            alert('ثبت نام موفق بود، اکنون وارد شوید');
+            window.location.href = 'login.html';
+        } else {
+            alert(data.error || 'خطا در ثبت نام');
+        }
+    });
+    </script>
+</body>
+</html>

--- a/frontend/public/services.html
+++ b/frontend/public/services.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<title>services</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100 text-center">
+<h1 class="text-2xl font-bold mb-4">صفحه services</h1>
+<p>در دست ساخت.</p>
+<a href="index.html" class="text-blue-600">بازگشت</a>
+</body>
+</html>

--- a/frontend/public/user.html
+++ b/frontend/public/user.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>پنل کاربر</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 bg-gray-100">
+    <h1 class="text-2xl font-bold mb-4">سفارش‌های من</h1>
+    <table class="w-full text-right border" id="ordersTbl">
+        <thead>
+            <tr>
+                <th class="border px-2">شناسه</th>
+                <th class="border px-2">وضعیت</th>
+                <th class="border px-2">اقدام</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="config.js"></script>
+    <script>
+    async function loadOrders() {
+        const res = await fetch(window.API_BASE_URL + '/admin/orders', {
+            headers:{
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            }
+        });
+        const data = await res.json();
+        const uid = parseInt(localStorage.getItem('userID') || '0');
+        const tbody = document.querySelector('#ordersTbl tbody');
+        tbody.innerHTML = '';
+        data.filter(o => o.UserID == uid).forEach(o => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td class="border px-2">${o.ID}</td>`+
+                `<td class="border px-2">${o.Status}</td>`+
+                `<td class="border px-2"><button onclick="approve(${o.ID})" class='bg-blue-500 text-white px-2 rounded'>تایید</button></td>`;
+            tbody.appendChild(tr);
+        });
+    }
+    async function approve(id){
+        await fetch(window.API_BASE_URL + `/user/orders/${id}/approve`, {
+            method:'POST',
+            headers:{
+                'X-User-ID': localStorage.getItem('userID') || '',
+                'X-User-Role': localStorage.getItem('role') || ''
+            }
+        });
+        loadOrders();
+    }
+    loadOrders();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add config.js to allow setting API base URL
- flesh out HTML pages for login, register, ordering and roles
- update index navigation and README instructions

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_688323a5da2c832285b0e7903e1b1af0